### PR TITLE
gnulib: update to 2021-01-02

### DIFF
--- a/packages/devel/gnulib/package.mk
+++ b/packages/devel/gnulib/package.mk
@@ -3,8 +3,8 @@
 
 PKG_NAME="gnulib"
 # Match version with GNULIB_REVISION in grub bootstrap.conf
-PKG_VERSION="d271f868a8df9bbec29049d01e056481b7a1a263"
-PKG_SHA256="4e23415ae2977ffca15e07419ceff3e9334d0369eafc9e7ae2578f8dd9a4839c"
+PKG_VERSION="ebaa53c5f1253974c6f23bb1500d8de198e84ab8"
+PKG_SHA256="473ec80d80147ad45c38f8ea7bed2db973f266fddee853c646795e35ce928c39"
 PKG_LICENSE="GPL"
 PKG_SITE="https://savannah.gnu.org/git/?group=gnulib"
 PKG_URL="http://git.savannah.gnu.org/cgit/gnulib.git/snapshot/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/packages/tools/grub/patches/grub-gnulib-acprereq-2-64.patch
+++ b/packages/tools/grub/patches/grub-gnulib-acprereq-2-64.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac	2020-12-18 22:18:04.000000000 +0000
++++ b/configure.ac	2021-01-17 05:55:10.946679960 +0000
+@@ -49,7 +49,7 @@
+ program_prefix="${save_program_prefix}"
+ 
+ AM_INIT_AUTOMAKE([1.11])
+-AC_PREREQ(2.63)
++AC_PREREQ([2.64])
+ AC_CONFIG_SRCDIR([include/grub/dl.h])
+ AC_CONFIG_HEADER([config-util.h])
+ 


### PR DESCRIPTION
update d271f86 (2019-01-04) to ebaa53c (2021-01-02)
changelog: http://git.savannah.gnu.org/cgit/gnulib.git/tree/ChangeLog
news: http://git.savannah.gnu.org/cgit/gnulib.git/tree/NEWS

include patch to grub to support: gnulib-tool: *** minimum supported
autoconf version is 2.64. Try adding AC_PREREQ([2.64]) to your
configure.ac.