### PR TITLE
setuptools: update to 52.0.0

### DIFF
--- a/packages/python/devel/setuptools/package.mk
+++ b/packages/python/devel/setuptools/package.mk
@@ -3,8 +3,8 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="setuptools"
-PKG_VERSION="51.1.2"
-PKG_SHA256="1f3db173c1d8f8753dce0b6c18017955863fc39a0613e5c20bfdd107f331fafb"
+PKG_VERSION="52.0.0"
+PKG_SHA256="ff0c74d1b905a224d647f99c6135eacbec2620219992186b81aa20012bc7f882"
 PKG_LICENSE="OSS"
 PKG_SITE="https://pypi.org/project/setuptools"
 PKG_URL="https://github.com/pypa/setuptools/archive/v${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
update 51.1.2 (2021-01-09) to 52.0.0 (2021-01-24)
release history: https://pypi.org/project/setuptools/#history
log: https://github.com/pypa/setuptools/compare/v51.1.2...v52.0.0
change log: https://github.com/pypa/setuptools/blob/main/CHANGES.rst