### PR TITLE
libopenmpt: update to 0.4.17

### DIFF
--- a/packages/audio/libopenmpt/package.mk
+++ b/packages/audio/libopenmpt/package.mk
@@ -3,11 +3,11 @@
 # Copyright (C) 2019-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libopenmpt"
-PKG_VERSION="0.4.16"
-PKG_SHA256="4fb4d9901390e2129f8609a2e369ad47c356145664dacbbaece562f2cf51e6d4"
+PKG_VERSION="0.4.17"
+PKG_SHA256="1df99191400c62dbdfd144f5ffd6aedbfd39fb9c6c47e83355a222632b793593"
 PKG_LICENSE="BSD"
-PKG_SITE="http://lib.openmpt.org/libopenmpt/"
-PKG_URL="http://lib.openmpt.org/files/libopenmpt/src/${PKG_NAME}-${PKG_VERSION}+release.autotools.tar.gz"
+PKG_SITE="https://lib.openmpt.org/libopenmpt/"
+PKG_URL="https://lib.openmpt.org/files/libopenmpt/src/${PKG_NAME}-${PKG_VERSION}+release.autotools.tar.gz"
 PKG_DEPENDS_TARGET="toolchain libogg libvorbis zlib"
 PKG_LONGDESC="libopenmpt renders mod music files as raw audio data, for playing or conversion."
 PKG_BUILD_FLAGS="+pic"


### PR DESCRIPTION
update 0.4.16 (2020-11-30) to 0.4.17 (2021-01-31)
changelog: https://lib.openmpt.org/libopenmpt/2021/01/31/releases-0.5.5-0.4.17-0.3.26/
change url to https as openmpt.org is now HSTS